### PR TITLE
fix(app): `app` imported after `dotenv.config()`

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,8 +1,9 @@
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
-const app = require("./app");
 
 dotenv.config({ path: "./config.env" });
+
+const app = require("./app");
 
 const port = process.env.PORT || 4200;
 


### PR DESCRIPTION
Now `morgan` middleware can finally add logs in development server, by simply moving the import line 