### PR TITLE
fix(limit): removed the default limit of 25 in pagination in the apiFeatures.js file

### DIFF
--- a/utils/apiFeatures.js
+++ b/utils/apiFeatures.js
@@ -40,7 +40,7 @@ class APIFeatures {
 
   paginate() {
     const page = this.queryString.page * 1 || 1;
-    const limit = this.queryString.limit * 1 || 25;
+    const limit = this.queryString.limit * 1;
     const skip = (page - 1) * limit;
 
     this.query = this.query.skip(skip).limit(limit);


### PR DESCRIPTION
Removed the default limit of 25 in pagination in the apiFeatures.js file