### PR TITLE
fix(api): virtual field `hours` visible only when it can be calculated

### DIFF
--- a/models/activityModel.js
+++ b/models/activityModel.js
@@ -46,6 +46,10 @@ const activitySchema = new mongoose.Schema(
 
 activitySchema.virtual("hours").get(function () {
   const hours = (this.endTime - this.startTime) / (60 * 60 * 1000);
+  if (isNaN(hours)) {
+    delete this.hours;
+    return;
+  }
   return hours.toFixed(2);
 });
 


### PR DESCRIPTION
an alternative would have been to use a native method `.lean()`

```js
// inside `handlerFactory.getAll`

/* ... */

const features = new APIFeatures(Model.find(filter).lean({ virtuals: false }), req.query)
      .filter()
      .sort()
      .limitFields()
      .paginate();
```

but I fear that would have been an overkill for any virtual field for the other resources Schemas.