### PR TITLE
fix(controller): count results with limit and totalDocuments within filter

### DIFF
--- a/controllers/activityController.js
+++ b/controllers/activityController.js
@@ -35,15 +35,19 @@ exports.createActivity = catchAsync(async (req, res, next) => {
 });
 
 exports.personalActivities = catchAsync(async (req, res, next) => {
-  let filter = {};
+  let filter = { userID: req.user.id };
 
+  if (req.query.startTime) {
+    filter.startTime = { $gte: new Date(req.query.startTime.gte) };
+  }
   if (req.query.endTime) {
     const endTime = new Date(req.query.endTime.lte);
     endTime.setHours(23, 59, 59, 999);
+    if (!filter.startTime) filter.startTime = {};
+    filter.endTime = { $lte: endTime };
     req.query.endTime.lte = endTime;
   }
-
-  filter = { userID: req.user.id };
+  if (req.query.taskName) filter.taskName = req.query.taskName;
 
   const totalDocuments = await Activity.countDocuments(filter);
 


### PR DESCRIPTION
Better refactoring the `filter` and `req.query` because each one will be used separately, by `Activity.countDocuments()` and by `APIFeatures.filter()`

This way `totalDocuments` shows how many activities are found within a certain range
Meanwhile `results` shows how many activities can be paginated with a certain `limit`